### PR TITLE
fix(ci): semver sorting

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,9 @@ jobs:
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             'https://api.github.com/repos/gorhill/ublock/tags' | \
-            jq -r '[.[].name | select(test("^[0-9]"))] | sort_by(.) | last')"
+            jq -r '[.[].name | select(test("^[0-9]"))] | .[]')" | \
+            sort -rV | \
+            head -1
           if [[ "$UPSTREAM_TAG" == 'null' ]]; then
             echo "ERROR: Failed to retrieve upstream version!"
             exit 1

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,9 +23,9 @@ jobs:
             -H 'Accept: application/vnd.github+json' \
             -H 'X-GitHub-Api-Version: 2022-11-28' \
             'https://api.github.com/repos/gorhill/ublock/tags' | \
-            jq -r '[.[].name | select(test("^[0-9]"))] | .[]')" | \
+            jq -r '[.[].name | select(test("^[0-9]"))] | .[]' | \
             sort -rV | \
-            head -1
+            head -1)"
           if [[ "$UPSTREAM_TAG" == 'null' ]]; then
             echo "ERROR: Failed to retrieve upstream version!"
             exit 1


### PR DESCRIPTION
jq's `sort_by` looks like using ASCII sorting resulting in false positive with semver. It's way simple to stick with GNU `sort` with `-V` flag here.